### PR TITLE
fix: call undecleared waitpid function on linux

### DIFF
--- a/src/flutter_pty_unix.c
+++ b/src/flutter_pty_unix.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <sys/wait.h>
 
 #include "forkpty.h"
 #include "flutter_pty.h"


### PR DESCRIPTION
When attempting to build a project on Debian Bookworm (unstable), an error is encountered in the file `flutter_pty/src/flutter_pty_unix.c` at line 114. The error message indicates that the function `waitpid` is undeclared and that ISO C99 and later versions do not support implicit function declarations.

To resolve this issue, you can include the header file `<sys/wait.h>` in the `flutter_pty_unix.c` file. This header file provides the declaration for the `waitpid` function.

By adding `#include <sys/wait.h>` at the top of the file, the compiler will be able to recognize and use the `waitpid` function correctly, resolving the error.